### PR TITLE
Improve error reporting for inconsistent problem dimensions

### DIFF
--- a/.changeset/better-dimension-error-reporting.md
+++ b/.changeset/better-dimension-error-reporting.md
@@ -1,0 +1,13 @@
+---
+default: patch
+---
+
+# Improve error reporting for inconsistent problem dimensions
+
+Enhanced the validation error messages to provide specific details about dimension mismatches:
+- Reports which constraint row has the wrong number of coefficients
+- Shows the actual vs expected counts for all dimension errors
+- Reports multiple dimension errors at once instead of stopping at the first one
+- Provides clearer context about what each dimension should match
+
+This makes it much easier to debug optimization problems with incorrect dimensions.

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,10 +59,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const validationResult = OptimizationArgsSchema.safeParse(request.params.arguments);
 
   if (!validationResult.success) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      `Invalid parameters: ${validationResult.error.errors.map((e) => e.message).join(", ")}`,
-    );
+    const errorMessages = validationResult.error.errors.map((e) => e.message);
+    throw new McpError(ErrorCode.InvalidParams, `Invalid parameters: ${errorMessages.join(", ")}`, {
+      errors: errorMessages,
+    });
   }
 
   const { problem, options } = validationResult.data;


### PR DESCRIPTION
## Summary

This PR improves the error reporting when problem dimensions are inconsistent, providing specific details about what went wrong rather than a generic error message.

Fixes #11

## Changes

- Replaced the generic `refine()` validation with `superRefine()` in `ProblemSchema`
- Added specific error messages for each dimension mismatch case, including:
  - Expected vs actual counts
  - Which specific array/row has the mismatch
  - Clear context about what the dimensions should match

## Key Areas for Review

1. **Error message clarity** in `src/schemas.ts:47-94` - Please verify the error messages are clear and helpful
2. **Test coverage** in `src/index.test.ts` - Added comprehensive tests for all dimension mismatch scenarios
3. **Path reporting** - The errors now include the exact path to the problematic data (e.g., `["constraints", "matrix", 2]`)

## Example Error Output

Before:
```
Problem dimensions are inconsistent
```

After:
```
Constraint row 2 has 4 coefficients but expected 3 (matching the number of variables in the objective function)
```

This provides developers with actionable information to fix their LP problem definitions.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>