### PR TITLE
Fix server version reporting

### DIFF
--- a/.changeset/fix-server-version-reporting.md
+++ b/.changeset/fix-server-version-reporting.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Fix server version reporting
+
+Server now dynamically reads version from package.json instead of using hardcoded "0.0.1".

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawn, ChildProcess } from "child_process";
 import { once } from "events";
+import packageJson from "../package.json";
 
 describe("Node.js Version Check", () => {
   it("should start successfully with Node.js >= 16", async () => {
@@ -134,7 +135,7 @@ describe("HiGHS MCP Server", () => {
       expect(response.result).toBeDefined();
       expect(response.result.protocolVersion).toBe("2024-11-05");
       expect(response.result.serverInfo.name).toBe("highs-mcp");
-      expect(response.result.serverInfo.version).toBe("0.0.1");
+      expect(response.result.serverInfo.version).toBe(packageJson.version);
     });
 
     it("should list available tools", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,13 +11,14 @@ import highsLoader from "highs";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { OptimizationArgsSchema } from "./schemas.js";
 import { problemToLPFormat } from "./lp-format.js";
+import packageJson from "../package.json";
 
 const TOOL_NAME = "optimize-mip-lp-tool";
 
 const server = new Server(
   {
     name: "highs-mcp",
-    version: "0.0.1",
+    version: packageJson.version,
   },
   {
     capabilities: {
@@ -143,7 +144,7 @@ async function main() {
   const majorVersion = parseInt(nodeVersion.split(".")[0].substring(1));
 
   console.error(`Node.js version: ${nodeVersion}`);
-  console.error("Starting HiGHS MCP server v0.0.1...");
+  console.error(`Starting HiGHS MCP server v${packageJson.version}...`);
 
   // Check if Node.js version is >= 16.0.0
   if (majorVersion < 16) {


### PR DESCRIPTION
## Summary

Fixes #17

The server was reporting a hardcoded version "0.0.1" instead of using the version from package.json (currently "0.0.3"). This fix makes the server dynamically read and report the correct version.

## Changes

- Import package.json and use its version field in server initialization
- Update console startup message to show correct version
- Update test to verify against actual package.json version instead of hardcoded value

## Areas for verification

- Server startup message now shows correct version matching package.json
- MCP server info response returns the correct version
- Tests pass with dynamic version checking

🤖 Generated with [Claude Code](https://claude.ai/code)